### PR TITLE
Don't try to pass uploaded files as a dict to requests

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,3 +1,1 @@
-* Forwarding file uploads to the downstream endpoint has not been tested and
-  it probably doesn't work
-* There are no integration tests.
+* Add integration tests.

--- a/djproxy/views.py
+++ b/djproxy/views.py
@@ -103,8 +103,7 @@ class HttpProxy(View):
             self.headers, self.ignored_request_headers)
         result = request(
             method=self.request.method, url=self.proxy_url, headers=headers,
-            data=self.request.body, files=self.request.FILES,
-            params=self.query_string)
+            data=self.request.body, params=self.query_string)
 
         response = HttpResponse(result.content, status=result.status_code)
         forwardable_headers = self.filter_headers(

--- a/tests/view_configuration_tests.py
+++ b/tests/view_configuration_tests.py
@@ -60,7 +60,7 @@ class HttpProxyUrlConstructionWithoutURLKwarg(TestCase, RequestPatchMixin):
         """only contains base_url"""
         self.request.assert_called_once_with(
             method=ANY, url="https://google.com/", data=ANY, headers=ANY,
-            files=ANY, params=ANY)
+            params=ANY)
 
 
 class HttpProxyUrlConstructionWithURLKwarg(TestCase, RequestPatchMixin):
@@ -80,7 +80,7 @@ class HttpProxyUrlConstructionWithURLKwarg(TestCase, RequestPatchMixin):
         """urljoins base_url and url kwarg"""
         self.request.assert_called_once_with(
             method=ANY, url="https://google.com/yay/", data=ANY, headers=ANY,
-            files=ANY, params=ANY)
+            params=ANY)
 
 
 class HttpProxyUrlConstructionWithQueryStringPassingEnabled(
@@ -99,8 +99,7 @@ class HttpProxyUrlConstructionWithQueryStringPassingEnabled(
 
     def test_sends_query_string_to_proxied_endpoint(self):
         self.request.assert_called_once_with(
-            method=ANY, url=ANY, data=ANY, headers=ANY, files=ANY,
-            params='yay=foo,bar')
+            method=ANY, url=ANY, data=ANY, headers=ANY, params='yay=foo,bar')
 
 
 class HttpProxyUrlConstructionWithoutQueryStringPassingEnabled(
@@ -121,4 +120,4 @@ class HttpProxyUrlConstructionWithoutQueryStringPassingEnabled(
 
     def test_doesnt_sends_query_string_to_proxied_endpoint(self):
         self.request.assert_called_once_with(
-            method=ANY, url=ANY, data=ANY, headers=ANY, files=ANY, params='')
+            method=ANY, url=ANY, data=ANY, headers=ANY, params='')


### PR DESCRIPTION
Django's `self.request.body` is the incoming request body as a byte stream, which works just fine for passing file uploads off downstream via the request library's `data` parameter.

This change fixes file uploads.
