### PR TITLE
Add empty middleware setting to quiet warning

### DIFF
--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -12,6 +12,8 @@ DATABASES = {
     }
 }
 
+MIDDLEWARE_CLASSES = []
+
 INSTALLED_APPS = (
     'djproxy',
 )


### PR DESCRIPTION
Before this change, starting a dev server would give this warning:

```
Performing system checks...

System check identified some issues:

WARNINGS:
?: (1_7.W001) MIDDLEWARE_CLASSES is not set.
        HINT: Django 1.7 changed the global defaults for the MIDDLEWARE_CLASSES. django.contrib.sessions.middleware.SessionMiddleware, django.contrib.auth.m
iddleware.AuthenticationMiddleware, and django.contrib.messages.middleware.MessageMiddleware were removed from the defaults. If your project needs these mid
dleware then you should configure this setting.
```