### PR TITLE
Add X-Forwarded-Prefix header to reverse proxies

### DIFF
--- a/djproxy/views.py
+++ b/djproxy/views.py
@@ -136,7 +136,7 @@ class HttpProxy(View):
         headers['X-Forwarded-For'] = self.xff
 
         for prefix, url in self.reverse_urls:
-            if url == self.proxy_url and self.request.path.startswith(prefix):
+            if self.proxy_url.startswith(url) and self.request.path.startswith(prefix):
                 headers['X-Forwarded-Prefix'] = prefix
 
         result = request(

--- a/djproxy/views.py
+++ b/djproxy/views.py
@@ -135,6 +135,10 @@ class HttpProxy(View):
         headers['X-Forwarded-Host'] = self.request.get_host()
         headers['X-Forwarded-For'] = self.xff
 
+        for prefix, url in self.reverse_urls:
+            if url == self.proxy_url and self.request.path.startswith(prefix):
+                headers['X-Forwarded-Prefix'] = prefix
+
         result = request(
             method=self.request.method, url=self.proxy_url, headers=headers,
             data=self.request.body, params=self.query_string,

--- a/tests/reverse_url_tests.py
+++ b/tests/reverse_url_tests.py
@@ -10,7 +10,7 @@ class HttpProxyReverseURLRuleProcessing(TestCase, RequestPatchMixin):
     """HttpProxy reverse URL rule processing"""
     def setUp(self):
         self.proxy = ReverseProxy.as_view()
-        self.browser_request = RequestFactory().get('/google/')
+        self.browser_request = RequestFactory().get('/google/foo/')
 
         # Simulate a downstream response that has location headers
         self.patch_request(Mock(headers={

--- a/tests/reverse_url_tests.py
+++ b/tests/reverse_url_tests.py
@@ -20,7 +20,7 @@ class HttpProxyReverseURLRuleProcessing(TestCase, RequestPatchMixin):
             'Blurp-Location': 'https://google.com/foo/'
         }))
 
-        self.response = self.proxy(self.browser_request)
+        self.response = self.proxy(self.browser_request, url='foo/')
 
     def test_patches_the_location_header(self):
         self.assertEqual(

--- a/tests/reverse_url_tests.py
+++ b/tests/reverse_url_tests.py
@@ -10,7 +10,7 @@ class HttpProxyReverseURLRuleProcessing(TestCase, RequestPatchMixin):
     """HttpProxy reverse URL rule processing"""
     def setUp(self):
         self.proxy = ReverseProxy.as_view()
-        self.browser_request = RequestFactory().get('/')
+        self.browser_request = RequestFactory().get('/google/')
 
         # Simulate a downstream response that has location headers
         self.patch_request(Mock(headers={
@@ -37,3 +37,8 @@ class HttpProxyReverseURLRuleProcessing(TestCase, RequestPatchMixin):
     def test_leaves_non_location_headers_unchanged(self):
         self.assertEqual(
             self.response['Blurp-Location'], 'https://google.com/foo/')
+
+    def test_attaches_x_forwarded_prefix_header(self):
+        _, request_kwargs = self.request.call_args
+        headers = request_kwargs['headers']
+        self.assertEqual(headers['X-Forwarded-Prefix'], '/google/')


### PR DESCRIPTION
So the proxied app can know what path it's proxied at. This will allow it to do things like fix URLs in REST API responses.

@thomasw I thought this would work, and the test does pass, but when I install this to my local application that's using `generate_routes`, it's not sending the header. Any ideas?