### PR TITLE
Send X-Forwarded-Proto downstream

### DIFF
--- a/djproxy/proxy_middleware.py
+++ b/djproxy/proxy_middleware.py
@@ -91,6 +91,16 @@ class AddXFH(object):
         return kwargs
 
 
+class AddXFP(object):
+    """Add a X-Forwarded-Proto header to the upstream request."""
+
+    def process_request(self, proxy, request, **kwargs):
+        proto = 'https' if request.is_secure() else 'http'
+        kwargs['headers']['X-Forwarded-Proto'] = proto
+
+        return kwargs
+
+
 class ProxyPassReverse(object):
 
     """Applies reverse url rules to location headers like ProxyPassReverse.

--- a/djproxy/views.py
+++ b/djproxy/views.py
@@ -24,6 +24,7 @@ class HttpProxy(View):
     proxy_middleware = [
         'djproxy.proxy_middleware.AddXFF',
         'djproxy.proxy_middleware.AddXFH',
+        'djproxy.proxy_middleware.AddXFP',
         'djproxy.proxy_middleware.ProxyPassReverse'
     ]
     pass_query_string = True

--- a/tests/middleware_tests.py
+++ b/tests/middleware_tests.py
@@ -3,7 +3,7 @@ from django.test.client import RequestFactory
 from mock import Mock
 from unittest2 import TestCase
 
-from djproxy.proxy_middleware import AddXFF, AddXFH, ProxyPassReverse
+from djproxy.proxy_middleware import AddXFF, AddXFH, AddXFP, ProxyPassReverse
 from djproxy.request import DownstreamRequest
 
 
@@ -29,6 +29,23 @@ class AddXFHMiddlewareTest(TestCase):
     def test_adds_an_XFH_header(self):
         self.assertEqual(
             self.kwargs['headers']['X-Forwarded-Host'], 'testserver')
+
+
+class AddXFPMiddlewareTest(TestCase):
+    def get_kwargs(self, secure):
+        request = Mock()
+        request.is_secure.return_value = secure
+        return AddXFP().process_request(Mock(), request, headers={})
+
+    def test_sets_XFP_header_to_https_if_request_is_secure(self):
+        kwargs = self.get_kwargs(secure=True)
+        self.assertEqual(
+            kwargs['headers']['X-Forwarded-Proto'], 'https')
+
+    def test_sets_XFP_header_to_http_if_request_is_not_secure(self):
+        kwargs = self.get_kwargs(secure=False)
+        self.assertEqual(
+            kwargs['headers']['X-Forwarded-Proto'], 'http')
 
 
 class ProxyPassReverseTest(TestCase):


### PR DESCRIPTION
This helps the proxied service know if a request is secure even if there's an http/https mismatch up/downstream.

Related: https://docs.djangoproject.com/en/1.6/ref/settings/#secure-proxy-ssl-header