### PR TITLE
Make django compatibility consistent with officially supported django versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
         # 1.11 is the last Django version to support python 2.7
         - python: 2.7
           env: DJANGO_VERSION=1.11
-        - python: pypy2.7
+        - python: pypy
           env: DJANGO_VERSION=1.11
     exclude:
         # Django 2.0 is the last version to support Python <= 3.4.

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ python:
     - 3.4
     - 3.5
     - 3.6
-    - pypy
+    - pypy3.4
+    - pypy3.5
 env:
     - DJANGO_VERSION=1.11
     - DJANGO_VERSION=2.0
@@ -15,6 +16,8 @@ matrix:
     include:
         # 1.11 is the last Django version to support python 2.7
         - python: 2.7
+          env: DJANGO_VERSION=1.11
+        - python: pypy2.7
           env: DJANGO_VERSION=1.11
 install:
     - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,10 @@ python:
     - 3.6
     - pypy
 env:
-    - DJANGO_VERSION = 1.11
-    - DJANGO_VERSION = 2.0
-    - DJANGO_VERSION = 2.1
+    - DJANGO_VERSION=1.11
+    - DJANGO_VERSION=2.0
+    - DJANGO_VERSION=2.1
+    - DJANGO_VERSION='latest'
 matrix:
     include:
         # 1.11 is the last Django version to support python 2.7
@@ -18,9 +19,6 @@ matrix:
 install:
     - pip install -r requirements.txt
     - if [[ $DJANGO_VERSION != 'latest' ]]; then pip install django==$DJANGO_VERSION; fi
-    # Django 2.0 is supposed to drop support for everything but python>=3.5
-    # and this config file will need to be refactored whenever that is released
-    - if [[ $DJANGO_VERSION == 'latest' ]]; then pip install --upgrade 'django<2.0'; fi
 script:
     - python setup.py nosetests
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,16 @@ matrix:
           env: DJANGO_VERSION=1.11
         - python: pypy2.7
           env: DJANGO_VERSION=1.11
+    exclude:
+        # Django 2.0 is the last version to support Python <= 3.4.
+        - python: 3.4
+          env: DJANGO_VERSION=2.1
+        - python: 3.4
+          env: DJANGO_VERSION='latest'
+        - python: pypy3.4
+          env: DJANGO_VERSION=2.1
+        - python: pypy3.4
+          env: DJANGO_VERSION='latest'
 install:
     - pip install -r requirements.txt
     - if [[ $DJANGO_VERSION != 'latest' ]]; then pip install django==$DJANGO_VERSION; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
     - 3.4
     - 3.5
     - 3.6
-    - 3.7
+    - 3.7-dev
     - pypy3.5
 env:
     - DJANGO_VERSION=1.11

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ cache: pip
 python:
     - 3.4
     - 3.5
+    - 3.6
     - pypy
 env:
     - DJANGO_VERSION = 1.11

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,34 +2,18 @@ sudo: false
 language: python
 cache: pip
 python:
-    - 2.7
     - 3.4
     - 3.5
     - pypy
 env:
-    - DJANGO_VERSION=1.7.11
-    - DJANGO_VERSION=1.8.12
-    - DJANGO_VERSION=1.9.8
-    - DJANGO_VERSION=1.10.0
-    - DJANGO_VERSION=latest
+    - DJANGO_VERSION = 1.11
+    - DJANGO_VERSION = 2.0
+    - DJANGO_VERSION = 2.1
 matrix:
     include:
+        # 1.11 is the last Django version to support python 2.7
         - python: 2.7
-          env: DJANGO_VERSION=1.4.22
-        - python: 2.7
-          env: DJANGO_VERSION=1.5.12
-        - python: 2.7
-          env: DJANGO_VERSION=1.6.11
-        - python: pypy
-          env: DJANGO_VERSION=1.4.22
-        - python: pypy
-          env: DJANGO_VERSION=1.5.12
-        - python: pypy
-          env: DJANGO_VERSION=1.6.11
-    exclude:
-        # Django 1.7 is a special case. It has python 3.4 support, but not 3.5
-        - python: 3.5
-          env: DJANGO_VERSION=1.7.11
+          env: DJANGO_VERSION=1.11
 install:
     - pip install -r requirements.txt
     - if [[ $DJANGO_VERSION != 'latest' ]]; then pip install django==$DJANGO_VERSION; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
     - 3.4
     - 3.5
     - 3.6
+    - 3.7
     - pypy3.5
 env:
     - DJANGO_VERSION=1.11

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ python:
     - 3.4
     - 3.5
     - 3.6
-    - pypy3.4
     - pypy3.5
 env:
     - DJANGO_VERSION=1.11
@@ -24,10 +23,6 @@ matrix:
         - python: 3.4
           env: DJANGO_VERSION=2.1
         - python: 3.4
-          env: DJANGO_VERSION='latest'
-        - python: pypy3.4
-          env: DJANGO_VERSION=2.1
-        - python: pypy3.4
           env: DJANGO_VERSION='latest'
 install:
     - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,13 +14,6 @@ env:
     - DJANGO_VERSION=latest
 matrix:
     include:
-        # The following versions don't work in python > 2.7
-        - python: 2.6
-          env: DJANGO_VERSION=1.4.22
-        - python: 2.6
-          env: DJANGO_VERSION=1.5.12
-        - python: 2.6
-          env: DJANGO_VERSION=1.6.11
         - python: 2.7
           env: DJANGO_VERSION=1.4.22
         - python: 2.7

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+dev
+---
+
+- Drop support for Python 2.6
+
 2.3.4
 -----
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ dev
 ---
 
 - Drop support for Python 2.6
+- Drop support for django < 1.11
 
 2.3.4
 -----

--- a/README.rst
+++ b/README.rst
@@ -29,9 +29,7 @@ one needs to use this in production, it should be fine as long as
 upstream responses aren't large. Performance can be further increased by
 aggressively caching upstream responses.
 
-Note that djproxy doesn't currently support websockets because django
-doesn't support them. I will investigate adding websocket support as
-soon as django has it.
+Note that djproxy doesn't currently support websockets.
 
 Installation
 ------------
@@ -40,10 +38,14 @@ Installation
 
     pip install djproxy
 
-djproxy requires requests >= 1.0.0, django >= 1.4.0 and python >= 2.6.
+djproxy requires requests >= 1.0.0, django >= 1.11 and python >= 2.7. The goal
+is to maintain compatibility with all versions of `Django that are still
+officially supported
+<https://www.djangoproject.com/download/#supported-versions>`_. However, djproxy
+may still work with older versions.
 
-It's currently tested against Django 1.4.x, 1.5.x, 1.6.x, 1.7.x, 1.9.x, and
-1.10.x.
+If you encounter issues using djproxy with a supported version of django, please
+report it.
 
 Usage
 -----

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,6 @@ twine
 wheel
 
 # Functional requirements
-django >=1.4,<1.7; python_version < '2.7'
-django; python_version >= '2.7'
+django
 requests>=1.0.0
 six>=1.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,12 @@
 # Testing
-coveralls==1.1
-flake8==2.5.4
-mock==1.3.0
+coveralls==1.5.1
+flake8==3.6.0
+mock==2.0.0
 nose==1.3.7
 pep257==0.7.0
-pyflakes==1.1.0
-spec==1.3.1
-testtube==1.0.0
+pyflakes==2.0.0
+spec==1.4.1
+testtube==1.1.0
 unittest2==1.1.0
 twine
 wheel

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,5 @@
 from codecs import open
-import multiprocessing  # noqa `python setup.py test` fix for python 2.6
 from setuptools import setup, find_packages
-import sys
 
 from djproxy import __author__, __doc__, __version__
 
@@ -9,10 +7,6 @@ install_requires = ['requests>=1.0.0', 'django>=1.4', 'six>=1.9.0']
 tests_require = [
     'mock==1.3.0', 'nose==1.3.7', 'unittest2==1.1.0', 'spec==1.3.1',
     'requests>=1.0.0']
-
-# Django >= 1.7 is not 2.6 compatible
-if sys.version_info[:2] < (2, 7):
-    install_requires += ['django<1.7']
 
 with open('README.rst', 'r', 'utf-8') as f:
     readme = f.read()
@@ -34,15 +28,10 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Topic :: Software Development :: Libraries',
-        'Framework :: Django :: 1.4',
-        'Framework :: Django :: 1.5',
-        'Framework :: Django :: 1.6',
-        'Framework :: Django :: 1.7',
-        'Framework :: Django :: 1.8',
-        'Framework :: Django :: 1.9',
-        'Framework :: Django :: 1.10',
+        'Framework :: Django :: 1.11',
+        'Framework :: Django :: 2.0',
+        'Framework :: Django :: 2.1',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: Implementation :: PyPy'
     ],
     test_suite='nose.collector'

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from djproxy import __author__, __doc__, __version__
 
 install_requires = ['requests>=1.0.0', 'django>=1.4', 'six>=1.9.0']
 tests_require = [
-    'mock==1.3.0', 'nose==1.3.7', 'unittest2==1.1.0', 'spec==1.3.1',
+    'mock==2.0.0', 'nose==1.3.7', 'unittest2==1.1.0', 'spec==1.4.1',
     'requests>=1.0.0']
 
 with open('README.rst', 'r', 'utf-8') as f:

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 from djproxy import __author__, __doc__, __version__
 
-install_requires = ['requests>=1.0.0', 'django>=1.4', 'six>=1.9.0']
+install_requires = ['requests>=1.0.0', 'django>=1.11', 'six>=1.9.0']
 tests_require = [
     'mock==2.0.0', 'nose==1.3.7', 'unittest2==1.1.0', 'spec==1.4.1',
     'requests>=1.0.0']
@@ -35,6 +35,7 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: Implementation :: PyPy'
     ],
     test_suite='nose.collector'

--- a/tests/header_passthrough_tests.py
+++ b/tests/header_passthrough_tests.py
@@ -20,7 +20,8 @@ class HttpProxyHeaderPassThrough(TestCase, RequestPatchMixin):
         self.browser_request.META['HTTP_UNNORMALIZED_HEADER'] = 'header value'
         self.browser_request.META['CONTENT_TYPE'] = 'header value'
 
-        self.request = self.patch_request(Mock(headers={'Fake-Header': '123'}))
+        self.request = self.patch_request(
+            Mock(status_code=400, headers={'Fake-Header': '123'}))
 
         self.proxy(self.browser_request)
 

--- a/tests/url_generate_routes_tests.py
+++ b/tests/url_generate_routes_tests.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import get_resolver
+from django.urls import get_resolver
 from mock import patch
 from unittest2 import TestCase
 


### PR DESCRIPTION
This updates the testing configuration, readme, and setup.py to make Django support claims/implementations/tests consistent with the officially supported versions listed at https://www.djangoproject.com/download/#supported-versions.

To facilitate this, the Python 2.6 testing configuration and backwards compatibility fixes have been removed. **Python 2.6 is no longer supported.**