### PR TITLE
use re_path instead of deprecated url method

### DIFF
--- a/djproxy/urls.py
+++ b/djproxy/urls.py
@@ -1,6 +1,13 @@
 import re
 
-from django.conf.urls import url
+# The django url function is deprecated as of django 3.1
+# We use its equivalent re_path to maintain compatibility
+# with older versions of django
+try:
+    from django.urls import re_path
+except ImportError as exception:
+    from django.conf.urls import url as re_path
+
 from six import iteritems
 
 from djproxy.views import HttpProxy
@@ -82,6 +89,6 @@ def generate_routes(config):
 
         proxy_view_function.csrf_exempt = config.get('csrf_exempt', True)
 
-        routes.append(url(pattern, proxy_view_function, name=name))
+        routes.append(re_path(pattern, proxy_view_function, name=name))
 
     return routes

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Testing
-coveralls==1.5.1
+coveralls==1.11.1
 flake8==3.6.0
 mock==2.0.0
 nose==1.3.7

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -1,13 +1,20 @@
-from django.conf.urls import url
+# The django url function is deprecated as of django 3.1
+# We use its equivalent re_path to maintain compatibility
+# with older versions of django
+try:
+    from django.urls import re_path
+except ImportError as exception:
+    from django.conf.urls import url as re_path
+
 
 from djproxy.urls import generate_routes
 from .test_views import LocalProxy, QuickTimeoutProxy, index
 
 
 urlpatterns = [
-    url(r'^some/content/.*$', index, name='index'),
-    url(r'^local_proxy/(?P<url>.*)$', LocalProxy.as_view(), name='proxy'),
-    url(r'^quick/(?P<url>.*)$', QuickTimeoutProxy.as_view(), name='proxy'),
+    re_path(r'^some/content/.*$', index, name='index'),
+    re_path(r'^local_proxy/(?P<url>.*)$', LocalProxy.as_view(), name='proxy'),
+    re_path(r'^quick/(?P<url>.*)$', QuickTimeoutProxy.as_view(), name='proxy'),
 ]
 
 urlpatterns += generate_routes({


### PR DESCRIPTION
use re_path instead of deprecated url method

For older versions of django, we use an alternate code path to retain support. 
The automatic tests are running correctly on python 2.7 with django 1.1 and python 3.8 with django 4.1.3