### PR TITLE
Implement middleware to handle multi set cookie

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -236,7 +236,7 @@ Proxy middleware
 HttpProxys support custom middleware for preprocessing data from
 downstream to be sent to upstream endpoints and for preprocessing
 response data before it is sent back downstream. ``X-Forwarded-Host``,
-``X-Forwarded-For``, ``X-Forwarded-Proto`` and the ``ProxyPassRevere``
+``X-Forwarded-For``, ``X-Forwarded-Proto``, ``ForwardSetCookie`` and the ``ProxyPassRevere``
 functionality area all implemented as middleware.
 
 HttProxy views are configured to execute particular middleware by


### PR DESCRIPTION
Related to #44 
Handles the transmission of multiple cookies returned by a server as multiple set-cookie headers.

Request merges the set-cookie headers into one. The default behavior is ok
if the server returns only one cookie per http response.

The browser will receive only one cookie.

```
{
    Set-Cookie: hello=world; Expires=Wed, 21 Oct 2015 07:28:00 GMT, world=hello
}
```

instead

```
{
    Set-Cookie: hello=world; Expires=Wed, 21 Oct 2015 07:28:00 GMT
    Set-Cookie: world=hello
}
```

more about this behavior

* https://github.com/urllib3/urllib3/commit/d8013cb111644a06eb5cb9bccce174a1a996078d
* https://stackoverflow.com/a/57131320
* https://github.com/psf/requests/issues/3957#issuecomment-1047539652